### PR TITLE
Fix value check in getGetOrPost and getPostOrGet methods

### DIFF
--- a/src/Library/HttpFundamental/Request.php
+++ b/src/Library/HttpFundamental/Request.php
@@ -544,7 +544,7 @@ class Request
     public function getGetOrPost($varname, $default = null)
     {
         $get = $this->getArgument($varname, $default);
-        if (empty($get)) {
+        if (!empty($get)) {
             return $get;
         }
         return $this->getData($varname, $default);
@@ -557,7 +557,7 @@ class Request
     public function getPostOrGet($varname, $default = null)
     {
         $post = $this->getData($varname, $default);
-        if (empty($post)) {
+        if (!empty($post)) {
             return $post;
         }
         return $this->getArgument($varname, $default);


### PR DESCRIPTION
In the getPostOrGet (and getGetOrPost) method, the $post value ($get) is checked as empty, and returned if it actually is empty, which is probably not what you want.
I have changed the if satements so that the value is returned if NOT empty, otherwise the $get value (or $post if using getGetOrPost) is returned.
